### PR TITLE
Pin Django 1.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Django
+Django<1.9
 django-json-field
 requests


### PR DESCRIPTION
Tests break on >=1.9, and this library is deprecated

@spra85 @MichaelButkovic 
